### PR TITLE
feat: adding static analysis tests

### DIFF
--- a/.github/actions/setup-localstack/action.yml
+++ b/.github/actions/setup-localstack/action.yml
@@ -1,0 +1,37 @@
+name: Setup LocalStack
+description: Setups LocalStack to run Terraform Tests against
+
+runs:
+  using: "composite"
+  steps:
+    - name: Restore Localstack Cache if it exists
+      id: cache-docker-localstack
+      uses: actions/cache@v3
+      with:
+        path: ci/cache/docker/localstack
+        key: cache-docker-localstack
+
+    - name: Update Localstack Image Cache if cache miss
+      shell: bash
+      if: steps.cache-docker-localstack.outputs.cache-hit != 'true'
+      run: docker pull localstack/localstack && mkdir -p ci/cache/docker/localstack && docker image save localstack/localstack --output ./ci/cache/docker/localstack/localstack.tar
+
+    - name: Use LocalStack Image Cache if cache hit
+      shell: bash
+      if: steps.cache-docker-localstack.outputs.cache-hit == 'true'
+      run: docker image load --input ./ci/cache/docker/localstack/localstack.tar
+
+    - name: Start LocalStack
+      shell: bash
+      run: |
+        pip install --upgrade pyopenssl
+        pip install localstack awscli-local[ver1] # install LocalStack cli and awslocal
+        localstack start -d                       # Start LocalStack in the background
+
+        echo "Waiting for LocalStack startup..."  # Wait 30 seconds for the LocalStack container
+        localstack wait -t 30                     # to become ready before timing out
+        echo "Startup complete"
+        cp test/localstack.tf test/terraform.tfvars .
+        mkdir route53_lambda
+        cp test/route53.tf test/localstack.tf test/lambda.tf route53_lambda/
+        zip -j route53_lambda/lambda.zip test/index.js

--- a/.github/actions/static-analysis-tests/action.yml
+++ b/.github/actions/static-analysis-tests/action.yml
@@ -1,0 +1,54 @@
+name: Terraform Static Analysis Tests
+description: Runs Terraform Static Analysis Tests - format, validate and plan
+
+runs:
+  using: "composite"
+  steps:
+    - name: Terraform Mock Route53, ACM and Lambda resources
+      working-directory: route53_lambda
+      shell: bash
+      run: |
+        terraform init
+        terraform apply -auto-approve
+
+    - name: Terraform Validate and Plan
+      shell: bash
+      run: |
+        terraform init
+        terraform fmt --recursive
+        terraform validate
+        terraform plan -lock=false -out terraform.plan
+        terraform show -no-color terraform.plan > terraform.text
+
+    - name: Report Terraform Plan
+      uses: actions/github-script@v6
+      with:
+        script: |
+          let stdout = '';
+          let stderr = '';
+
+          const options = {};
+          options.listeners = {
+            stdout: (data) => {
+              stdout += data.toString();
+            },
+            stderr: (data) => {
+              stderr += data.toString();
+            }
+          };
+          await exec.exec('cat', ['terraform.text'], options);
+
+          const output = `### Terraform Plan
+          <details><summary>Show Plan</summary>
+
+          \`\`\`\n
+          ${stdout}
+          \`\`\`
+
+          </details>`;
+          github.rest.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: output
+          })

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -10,3 +10,21 @@ jobs:
         with:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v5
+
+  hide-old-github-action-comments:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: int128/hide-comment-action@v1
+
+  static-analysis-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup LocalStack
+        id: setup-localstack
+        uses: ./.github/actions/setup-localstack
+
+      - name: Static Analysis Tests
+        id: static-analysis-tests
+        uses: ./.github/actions/static-analysis-tests

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ test/.terraform*
 test/terraform.tfstate*
 test/lambda.zip
 test/response.json
-terraform.tfvars
+./terraform.tfvars
 lambda.zip
 .DS_Store
 route53_lambda/
-localstack.tf
+./localstack.tf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.terraform*
+terraform.tfstate*
+test/test_output*
+test/.terraform*
+test/terraform.tfstate*
+test/lambda.zip
+test/response.json
+terraform.tfvars
+lambda.zip
+.DS_Store
+route53_lambda/
+localstack.tf

--- a/README.MD
+++ b/README.MD
@@ -23,64 +23,63 @@ module "apigateway" {
 ```
 
 <!-- BEGIN_TF_DOCS -->
-
 ## Requirements
 
 No requirements.
 
 ## Providers
 
-| Name                                             | Version |
-| ------------------------------------------------ | ------- |
-| <a name="provider_aws"></a> [aws](#provider_aws) | n/a     |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 
-| Name                                                        | Source                                           | Version |
-| ----------------------------------------------------------- | ------------------------------------------------ | ------- |
-| <a name="module_platform"></a> [platform](#module_platform) | github.com/FormidableLabs/terraform-aws-platform | v0.1    |
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_platform"></a> [platform](#module\_platform) | github.com/FormidableLabs/terraform-aws-platform | v0.1 |
 
 ## Resources
 
-| Name                                                                                                                                                                 | Type        |
-| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [aws_apigatewayv2_api.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api)                                            | resource    |
-| [aws_apigatewayv2_api_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api_mapping)                            | resource    |
-| [aws_apigatewayv2_domain_name.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name)                            | resource    |
-| [aws_apigatewayv2_integration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration)                            | resource    |
-| [aws_apigatewayv2_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route)                                        | resource    |
-| [aws_apigatewayv2_stage.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage)                                        | resource    |
-| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group)                                    | resource    |
-| [aws_lambda_permission.apigw_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission)                       | resource    |
-| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record)                                                | resource    |
-| [aws_acm_certificate.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate)                                       | data source |
-| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone)                                                 | data source |
+| Name | Type |
+|------|------|
+| [aws_apigatewayv2_api.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api) | resource |
+| [aws_apigatewayv2_api_mapping.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_api_mapping) | resource |
+| [aws_apigatewayv2_domain_name.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_domain_name) | resource |
+| [aws_apigatewayv2_integration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_integration) | resource |
+| [aws_apigatewayv2_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_route) | resource |
+| [aws_apigatewayv2_stage.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/apigatewayv2_stage) | resource |
+| [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_lambda_permission.apigw_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_route53_record.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_acm_certificate.wildcard](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/acm_certificate) | data source |
+| [aws_route53_zone.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_servicequotas_service_quota.throttling_burst_limit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/servicequotas_service_quota) | data source |
-| [aws_servicequotas_service_quota.throttling_rate_limit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/servicequotas_service_quota)  | data source |
+| [aws_servicequotas_service_quota.throttling_rate_limit](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/servicequotas_service_quota) | data source |
 
 ## Inputs
 
-| Name                                                                                                            | Description                                               | Type       | Default         | Required |
-| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------- | --------------- | :------: |
-| <a name="input_domain_name"></a> [domain_name](#input_domain_name)                                              | Top level domain name.                                    | `string`   | `"example.com"` |    no    |
-| <a name="input_enable_access_logs"></a> [enable_access_logs](#input_enable_access_logs)                         | Enable API Gateway Access Logs                            | `bool`     | `false`         |    no    |
-| <a name="input_lambda_function_invoke_arn"></a> [lambda_function_invoke_arn](#input_lambda_function_invoke_arn) | (Required) ARN of the lambda the API Gateway will invoke. | `string`   | n/a             |   yes    |
-| <a name="input_log_retention_in_days"></a> [log_retention_in_days](#input_log_retention_in_days)                | Log retention in number of days.                          | `number`   | `90`            |    no    |
-| <a name="input_namespace"></a> [namespace](#input_namespace)                                                    | n/a                                                       | `string`   | `""`            |    no    |
-| <a name="input_service"></a> [service](#input_service)                                                          | n/a                                                       | `string`   | n/a             |   yes    |
-| <a name="input_stage"></a> [stage](#input_stage)                                                                | n/a                                                       | `string`   | n/a             |   yes    |
-| <a name="input_tags"></a> [tags](#input_tags)                                                                   | Additional tags to apply to the log group.                | `map(any)` | `{}`            |    no    |
-| <a name="input_throttling_burst_limit"></a> [throttling_burst_limit](#input_throttling_burst_limit)             | n/a                                                       | `number`   | `null`          |    no    |
-| <a name="input_throttling_rate_limit"></a> [throttling_rate_limit](#input_throttling_rate_limit)                | n/a                                                       | `number`   | `null`          |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | Top level domain name. | `string` | `"example.com"` | no |
+| <a name="input_enable_access_logs"></a> [enable\_access\_logs](#input\_enable\_access\_logs) | Enable API Gateway Access Logs | `bool` | `false` | no |
+| <a name="input_enable_quota_limits"></a> [enable\_quota\_limits](#input\_enable\_quota\_limits) | n/a | `bool` | `true` | no |
+| <a name="input_lambda_function_invoke_arn"></a> [lambda\_function\_invoke\_arn](#input\_lambda\_function\_invoke\_arn) | (Required) ARN of the lambda the API Gateway will invoke. | `string` | n/a | yes |
+| <a name="input_log_retention_in_days"></a> [log\_retention\_in\_days](#input\_log\_retention\_in\_days) | Log retention in number of days. | `number` | `90` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | n/a | `string` | `""` | no |
+| <a name="input_service"></a> [service](#input\_service) | n/a | `string` | n/a | yes |
+| <a name="input_stage"></a> [stage](#input\_stage) | n/a | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Additional tags to apply to the log group. | `map(any)` | `{}` | no |
+| <a name="input_throttling_burst_limit"></a> [throttling\_burst\_limit](#input\_throttling\_burst\_limit) | n/a | `number` | `null` | no |
+| <a name="input_throttling_rate_limit"></a> [throttling\_rate\_limit](#input\_throttling\_rate\_limit) | n/a | `number` | `null` | no |
 
 ## Outputs
 
-| Name                                                                          | Description |
-| ----------------------------------------------------------------------------- | ----------- |
-| <a name="output_api"></a> [api](#output_api)                                  | n/a         |
-| <a name="output_apig_stage"></a> [apig_stage](#output_apig_stage)             | n/a         |
-| <a name="output_route53_record"></a> [route53_record](#output_route53_record) | n/a         |
-
+| Name | Description |
+|------|-------------|
+| <a name="output_api"></a> [api](#output\_api) | n/a |
+| <a name="output_apig_stage"></a> [apig\_stage](#output\_apig\_stage) | n/a |
+| <a name="output_route53_record"></a> [route53\_record](#output\_route53\_record) | n/a |
 <!-- END_TF_DOCS -->
 
 [maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg?color=brightgreen&style=flat

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,3 @@
+exports.handler = async (event, context) => {
+    return "Hello World";  // Echo back the first key value
+};

--- a/test/lambda.tf
+++ b/test/lambda.tf
@@ -1,0 +1,11 @@
+module "lambda" {
+  source = "github.com/FormidableLabs/terraform-aws-lambda?ref=v0.1.0"
+
+  filename = "lambda.zip"
+  handler  = "index.handler"
+  service  = "testLambda"
+  stage    = "development"
+  variables = {
+    "STAGE" = "development"
+  }
+}

--- a/test/localstack.tf
+++ b/test/localstack.tf
@@ -1,0 +1,38 @@
+provider "aws" {
+  access_key                  = "test"
+  secret_key                  = "test"
+  region                      = "us-east-1"
+  s3_use_path_style           = false
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    acm            = "http://localhost:4566"
+    apigateway     = "http://localhost:4566"
+    apigatewayv2   = "http://localhost:4566"
+    cloudformation = "http://localhost:4566"
+    cloudwatch     = "http://localhost:4566"
+    cloudwatchlogs = "http://localhost:4566"
+    dynamodb       = "http://localhost:4566"
+    ec2            = "http://localhost:4566"
+    es             = "http://localhost:4566"
+    elasticache    = "http://localhost:4566"
+    firehose       = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    kinesis        = "http://localhost:4566"
+    lambda         = "http://localhost:4566"
+    rds            = "http://localhost:4566"
+    redshift       = "http://localhost:4566"
+    route53        = "http://localhost:4566"
+    s3             = "http://s3.localhost.localstack.cloud:4566"
+    secretsmanager = "http://localhost:4566"
+    ses            = "http://localhost:4566"
+    sns            = "http://localhost:4566"
+    sqs            = "http://localhost:4566"
+    ssm            = "http://localhost:4566"
+    stepfunctions  = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+    servicequotas  = "http://localhost:4566"
+  }
+}

--- a/test/route53.tf
+++ b/test/route53.tf
@@ -1,0 +1,32 @@
+resource "aws_acm_certificate" "certificate" {
+  domain_name               = "example.com"
+  validation_method         = "DNS"
+  subject_alternative_names = ["*.example.com"]
+}
+
+resource "aws_acm_certificate_validation" "certificate_validation" {
+  certificate_arn         = aws_acm_certificate.certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+resource "aws_route53_zone" "api_zone" {
+  name    = "example.com"
+  comment = "Test Route 53 zone"
+}
+
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = aws_route53_zone.api_zone.zone_id
+}

--- a/test/terraform.tfvars
+++ b/test/terraform.tfvars
@@ -1,0 +1,4 @@
+stage                      = "development"
+service                    = "testLambda"
+lambda_function_invoke_arn = "arn:aws:lambda:us-east-1:000000000000:function:use1-development-testLambda"
+enable_quota_limits        = false

--- a/variables.tf
+++ b/variables.tf
@@ -48,3 +48,8 @@ variable "throttling_rate_limit" {
   type    = number
   default = null
 }
+
+variable "enable_quota_limits" {
+  type    = bool
+  default = true
+}


### PR DESCRIPTION
- Setup of Static Analysis for Terraform Module. Following the standard Test Pyramid idea here: 
![image](https://user-images.githubusercontent.com/71470776/204015846-ca7671d6-9fd6-4224-b011-f727c2082d22.png)
- Idea is to use `localstack` for these tests rather than create resources in our AWS account that will then be destroyed.
  - The reasoning behind this is that for _true_ Terraform infrastructure testing, you should deploy resources in a completely separate Sandbox AWS Account as to not affect any other production resources.
  - Using a separate Sandbox AWS Account however means having to set up infrastructure deletion cron jobs (using a tool like [cloud-nuke](https://github.com/gruntwork-io/cloud-nuke) for example)
  - The tradeoff is that setup of the `localstack` image can take up to ~2 mins, but I feel this is reasonable given we do not have to maintain an **extra** infrastructure deletion tool. If the GitHub Actions pipeline fails, no infrastructure is left in limbo; we restart the pipeline and away we go.
- Each Static Analysis Test will post a comment to the PR with the results.
  - If the Static Analysis fails, it will not report the result, and the pipeline will report as failed
- The Static Analysis Test comments can add up quickly when re-running pipelines. There is a `hide-old-github-action-comments` job at the start of each pipeline to minimize these PR comments from the `github-actions[bot]` to increase readability.

- Having _some_ tests is better than have zero tests and ideally we can add this localstack/Terratest template to our other Terraform Modules going forward to help catch any errors that result due to programmatic changes 👍 